### PR TITLE
add support for running naive ATS code

### DIFF
--- a/language/ats/ats.go
+++ b/language/ats/ats.go
@@ -1,0 +1,22 @@
+package ats
+
+import (
+    "path/filepath"
+    "../../util"
+    "../../cmd"
+)
+
+func Run(files []string) (string, string, error) {
+    workDir := filepath.Dir(files[0])
+    binName := "a.out"
+
+    sourceFiles := util.FilterByExtension(files, "dats")
+    args := append([]string{"patscc", "-o", binName}, sourceFiles...)
+    stdout, stderr, err := cmd.Run(workDir, args...)
+    if err != nil {
+        return stdout, stderr, err
+    }
+
+    binPath := filepath.Join(workDir, binName)
+    return cmd.Run(workDir, binPath)
+}

--- a/language/language.go
+++ b/language/language.go
@@ -2,6 +2,7 @@ package language
 
 import (
     "./assembly"
+    "./ats"
     "./bash"
     "./c"
     "./clojure"
@@ -36,6 +37,7 @@ type runFn func([]string) (string, string, error)
 
 var languages = map[string]runFn{
     "assembly": assembly.Run,
+    "ats": ats.Run,
     "bash": bash.Run,
     "c": c.Run,
     "clojure": clojure.Run,


### PR DESCRIPTION
The runner can run naive ATS codes. I suppose other advanced code running options can be achieved through a Makefile in the snippet and using a custom "make" command in the web interface. 
